### PR TITLE
Fix message box display issue for long file names ( #4 )

### DIFF
--- a/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
+++ b/src/main/java/org/jabref/gui/fieldeditors/LinkedFileViewModel.java
@@ -270,7 +270,7 @@ public class LinkedFileViewModel extends AbstractViewModel {
         if (existingFile.isPresent()) {
             overwriteFile = dialogService.showConfirmationDialogAndWait(
                     Localization.lang("File exists"),
-                    Localization.lang("'%0' exists. Overwrite file?", targetFileName),
+                    Localization.lang("Target file name: \n'%0'", targetFileName),
                     Localization.lang("Overwrite"));
 
             if (!overwriteFile) {


### PR DESCRIPTION
This submission will fix the problem that the content of the message box is difficult to read for a long file name. 
Format: "Target file name :\n{file_name}"

closes #4 